### PR TITLE
chore: rename query to body and add types

### DIFF
--- a/src/accounts/aggregate.ts
+++ b/src/accounts/aggregate.ts
@@ -1,10 +1,10 @@
-import { AccountsRequestResult } from '../types'
+import { AccountsAggregateBody, AccountsRequestResult } from '../types'
 import { Cluster, requestHeaders, tryExtractResultFromResponse } from '../utils'
 
 /** Configures the accounts aggregate request. */
 export type AccountsAggregateConfig = {
-  /** The query to execute. */
-  query: object
+  /** The request body. */
+  body: AccountsAggregateBody
   /** The cluster to execute the query on, i.e. mainnet or devnet. */
   cluster: Cluster
   /** The program whose accounts we are querying. */
@@ -18,13 +18,13 @@ export async function accountsAggregate<T = any>(
   host: string,
   config: AccountsAggregateConfig
 ) {
-  const { query, cluster, program, cacheControl } = config
+  const { body, cluster, program, cacheControl } = config
 
   const res = await fetch(
     `https://${host}/v1/${cluster}/${program}/aggregate` + `?apiKey=${apiKey}`,
     {
       headers: requestHeaders({ cacheControl }),
-      body: JSON.stringify(query),
+      body: JSON.stringify(body),
       method: 'POST',
     }
   )

--- a/src/accounts/filter-by-type.ts
+++ b/src/accounts/filter-by-type.ts
@@ -1,12 +1,12 @@
-import { AccountsRequestResultWithMetadata } from '../types'
+import { AccountsFilterBody, AccountsRequestResultWithMetadata } from '../types'
 import { Cluster, requestHeaders, tryExtractResultFromResponse } from '../utils'
 
 /** Configures the accounts filterByType request. */
 export type AccountsFilterByTypeConfig = {
   /** The type of account consider for the query. */
   accountType: string
-  /** The query to execute. */
-  query: object
+  /** The request body. */
+  body: AccountsFilterBody
   /** The cluster to execute the query on, i.e. mainnet or devnet. */
   cluster: Cluster
   /** The program whose accounts we are querying. */
@@ -24,7 +24,7 @@ export async function accountsFilterByType<T = any>(
   host: string,
   config: AccountsFilterByTypeConfig
 ) {
-  const { accountType, query, cluster, program, limit, offset, cacheControl } =
+  const { accountType, body, cluster, program, limit, offset, cacheControl } =
     config
 
   const res = await fetch(
@@ -32,7 +32,7 @@ export async function accountsFilterByType<T = any>(
       `/${accountType}?limit=${limit}&offset=${offset}&apiKey=${apiKey}`,
     {
       headers: requestHeaders({ cacheControl }),
-      body: JSON.stringify(query),
+      body: JSON.stringify(body),
       method: 'POST',
     }
   )

--- a/src/accounts/filter.ts
+++ b/src/accounts/filter.ts
@@ -1,10 +1,10 @@
-import { AccountsRequestResultWithMetadata } from '../types'
+import { AccountsFilterBody, AccountsRequestResultWithMetadata } from '../types'
 import { Cluster, requestHeaders, tryExtractResultFromResponse } from '../utils'
 
 /** Configures the accounts filter request. */
 export type AccountsFilterConfig = {
-  /** The query to execute. */
-  query: object
+  /** The request body. */
+  body: AccountsFilterBody
   /** The cluster to execute the query on, i.e. mainnet or devnet. */
   cluster: Cluster
   /** The program whose accounts we are querying. */
@@ -22,14 +22,14 @@ export async function accountsFilter<T = any>(
   host: string,
   config: AccountsFilterConfig
 ) {
-  const { query, cluster, program, limit, offset, cacheControl } = config
+  const { body, cluster, program, limit, offset, cacheControl } = config
 
   const res = await fetch(
     `https://${host}/v1/${cluster}/${program}/filter` +
       `?limit=${limit}&offset=${offset}&apiKey=${apiKey}`,
     {
       headers: requestHeaders({ cacheControl }),
-      body: JSON.stringify(query),
+      body: JSON.stringify(body),
       method: 'POST',
     }
   )

--- a/src/accounts/memcmp.ts
+++ b/src/accounts/memcmp.ts
@@ -1,10 +1,10 @@
-import { AccountsRequestResultWithMetadata } from '../types'
+import { AccountsRequestResultWithMetadata, AccountsMemcmpBody } from '../types'
 import { Cluster, requestHeaders, tryExtractResultFromResponse } from '../utils'
 
 /** Configures the accounts memcmp request. */
 export type AccountsMemcmpConfig = {
-  /** The query to execute. */
-  query: object
+  /** The request body. */
+  body: AccountsMemcmpBody
   /** The cluster to execute the query on, i.e. mainnet or devnet. */
   cluster: Cluster
   /** The program whose accounts we are querying. */
@@ -22,14 +22,14 @@ export async function accountsMemcmp<T = any>(
   host: string,
   config: AccountsMemcmpConfig
 ) {
-  const { query, cluster, program, limit, offset, cacheControl } = config
+  const { body, cluster, program, limit, offset, cacheControl } = config
 
   const res = await fetch(
     `https://${host}/v1/${cluster}/${program}/memcmp` +
       `?limit=${limit}&offset=${offset}&apiKey=${apiKey}`,
     {
       headers: requestHeaders({ cacheControl }),
-      body: JSON.stringify(query),
+      body: JSON.stringify(body),
       method: 'POST',
     }
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,52 @@ export type AccountsRequestResultWithMetadata<T> = AccountsRequestResult<
     hasMore: boolean
   }
 }
+
+// -----------------
+// Body Types
+// -----------------
+export const SortValues = [
+  1,
+  -1,
+  'asc',
+  'desc',
+  'ascending',
+  'descending',
+] as const
+export type SortValue = (typeof SortValues)[number]
+
+export type Sort = [string, SortValue][]
+
+export type Pagination = {
+  offset?: number
+  limit?: number
+  sort: Sort
+}
+
+// TODO(thlorenz): add proper type if possible
+export type Projection = any
+
+export type AccountsFilterBody = {
+  filter?: object
+  projection?: object
+  pagination?: Pagination
+}
+
+export type MemcmpFilter =
+  | {
+      memcmp: {
+        offset: number
+        bytes: string
+      }
+    }
+  | { dataSize: number }
+
+export type AccountsMemcmpBody = {
+  filters: MemcmpFilter[]
+  projection?: Projection
+  pagination?: Pagination
+}
+
+export type AccountsAggregateBody = {
+  pipeline: Record<string, any>[]
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,7 +22,6 @@ export function requestHeaders(headers: Partial<RequestHeaders> = {}) {
   const { cacheControl } = { ...DEFAULT_REQUEST_HEADERS, ...headers }
 
   return {
-    'cache-control': 'no-cache',
     'content-type': 'application/json',
     'x-ironforge-cache-control': cacheControl,
   }

--- a/test/accounts-sdk.ts
+++ b/test/accounts-sdk.ts
@@ -12,7 +12,7 @@ if (API_KEY == null) throw new Error('IF_PLATFORM_API_KEY not set')
 test('accounts-sdk: aggregate', async () => {
   const sdk = new IronforgeSdk(API_KEY)
   const { result, status } = await sdk.accounts.aggregate({
-    query: {
+    body: {
       pipeline: [
         {
           $match: {
@@ -56,7 +56,7 @@ test('accounts-sdk: filter by type', async (t) => {
   const sdk = new IronforgeSdk(API_KEY)
   const { result, status } = await sdk.accounts.filterByType({
     accountType: 'CandyMachine',
-    query: { filter: { 'data.data.price': 250 } },
+    body: { filter: { 'data.data.price': 250 } },
     cluster: 'devnet',
     program: 'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
     limit: 2,
@@ -76,7 +76,7 @@ test('accounts-sdk: filter by type', async (t) => {
 test('accounts-sdk: filter', async (t) => {
   const sdk = new IronforgeSdk(API_KEY)
   const { result, status } = await sdk.accounts.filter({
-    query: { filter: { 'data.data.price': 250 } },
+    body: { filter: { 'data.data.price': 250 } },
     cluster: 'devnet',
     program: 'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
     limit: 3,
@@ -149,7 +149,7 @@ test('accounts-sdk: findOne', async (t) => {
 test('accounts-sdk: memcmp', async (t) => {
   const sdk = new IronforgeSdk(API_KEY)
   const { result, status } = await sdk.accounts.memcmp({
-    query: {
+    body: {
       filters: [
         {
           memcmp: {


### PR DESCRIPTION
## Summary

Rename the _query_ to the request _body_ and added types for that body param.

## Details

Types were confirmed with the accounts-runtime of our edge-network.
